### PR TITLE
fixed content styling for packages page

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,7 +121,6 @@ const pins = [
   },
 ];
 
-
 // HTML string of Package cards to be printed to DOM
 const packageCardString = (item) => {
   return `<div class="card border-secondary m-3 bg-transparent" style="width: 20rem; height: 18rem;" id="${item.id}">
@@ -156,6 +155,8 @@ const packageMaker = (e) => {
   packages.push(newPackage);
   createCards(packages, packageCardString, '#package-container');
 };
+
+
 
 //Holly - card to print after submitting form
 const pinCard = (item) => {

--- a/main.js
+++ b/main.js
@@ -121,51 +121,42 @@ const pins = [
   },
 ];
 
+
+// HTML string of Package cards to be printed to DOM
+const packageCardString = (item) => {
+  return `<div class="card border-secondary m-3 bg-transparent" style="width: 20rem; height: 18rem;" id="${item.id}">
+            <div class="card-body text-secondary">
+              <img src="${item.iconImgSrc}" style="width: 3rem; height: 3rem;">
+              <h5 class="card-title">${item.name}</h5>
+              <p class="card-text">${item.description}</p>
+            </div>
+            <div class="d-flex flex-wrap mt-auto mx-auto mb-3">
+                <button type="button" class="btn btn-secondary m-1">Learn More</button>
+                <button type="button" class="btn btn-danger m-1" id="${item.id}">Delete</button>
+              </div>
+          </div>`;
+};
+
 // Creates new packages after package form is submitted
 const packageMaker = (e) => {
   e.preventDefault();
 
   const name = document.querySelector('#package-name').value;
   const description = document.querySelector('#package-description').value;
+  const iconImgSrc = document.querySelector('#package-img-src').value;
   const id = 1;
-  const newPackageCardString = (item) => {
-    return `<div class="card border-secondary mb-3 bg-transparent" style="width: 18rem; height: 18rem;" id="${item.id}">
-              <div class="card-body text-secondary">
-                <img src="${item.iconImgSrc}">
-                <h5 class="card-title">${item.name}</h5>
-                <p class="card-text">${item.description}</p>
-                <div class="d-flex align-contnent-end">
-                  <button type="button" class="btn btn-secondary">Learn More</button>
-                  <button type="button" class="btn btn-danger" id="${item.id}">Delete</button>
-                </div>
-              </div>
-            </div>`;
-  };
 
   const newPackage = {
     name,
     description,
+    iconImgSrc,
     id,
   };
 
   packages.push(newPackage);
-  createCards(packages, newPackageCardString, '#package-container');
+  createCards(packages, packageCardString, '#package-container');
 };
 
-// HTML string of Package cards to be printed to DOM
-const packageCardString = (item) => {
-  return `<div class="card border-secondary mb-3 bg-transparent" style="width: 18rem; height: 18rem;" id="${item.id}">
-            <div class="card-body text-secondary">
-              <img src="${item.iconImgSrc}">
-              <h5 class="card-title">${item.name}</h5>
-              <p class="card-text">${item.description}</p>
-              <div class="d-flex align-contnent-end">
-                <button type="button" class="btn btn-secondary">Learn More</button>
-                <button type="button" class="btn btn-danger" id="${item.id}">Delete</button>
-              </div>
-            </div>
-          </div>`;
-};
 //Holly - card to print after submitting form
 const pinCard = (item) => {
   return `<div class="card text-white bg-dark mb-3" style="max-width: 18rem;" id="${item.id}">

--- a/packages.html
+++ b/packages.html
@@ -15,65 +15,70 @@
     <title>Gitsub | Packages</title>
   </head>
   <body>
-<!-- NAVBAR -->
-  <nav class="navbar navbar-expand-lg navbar-dark">
-    <ul class="navbar-nav">
-      <li class="nav-item">
-        <a href="./" class="nav-link">Overview</a>
-      </li>
-      <li class="nav-item">
-        <a href="./repos.html" class="nav-link">Repositories</a>
-      </li>
-      <li class="nav-item">
-        <a href="./projects.html" class="nav-link">Projects</a>
-      </li>
-      <li class="nav-item">
-        <a href="./packages.html" class="nav-link">Packages</a>
-      </li>
-      <li class="nav-item">
-        <a href="./organizations.html" class="nav-link">Organizations</a>
-      </li>
-    </ul>
-  </nav>
-
-<!-- PROFILE CARD -->
-  <div class="col-sm-3 m-3" id="profile-card">
-    <!--Profile Card - aligned left--> 
-  </div>
-
-<!--This is for projects, repos, etc-->
-  <div class="w-100"> 
-    <div class="container d-flex flex-wrap" id="package-container">
-      
-    </div>
-
-<!--For each page's create & submit form-->
-    <div class="container">  
-      <div id="package-form-container">
-<!--Form-->
-        <div class="mb-3">
-          <label for="title" class="form-label">Name</label>
-          <input
-            type="text"
-            class="form-control"
-            id="package-name"
-            placeholder="New Package Name"
-          />
-        </div>
-        <div>
-          <label for="description" class="form-label">Description</label>
-          <textarea
-            class="form-control"
-            id="package-description"
-            rows="6"
-          ></textarea>
-        </div>
-        <button type="button" class="btn btn-outline-info" id="create-package">Submit</button>
+  <!-- TOP NAV BAR -->
+    <nav class="navbar navbar-expand-lg navbar-dark">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a href="./" class="nav-link">Overview</a>
+        </li>
+        <li class="nav-item">
+          <a href="./repos.html" class="nav-link">Repositories</a>
+        </li>
+        <li class="nav-item">
+          <a href="./projects.html" class="nav-link">Projects</a>
+        </li>
+        <li class="nav-item">
+          <a href="./packages.html" class="nav-link">Packages</a>
+        </li>
+        <li class="nav-item">
+          <a href="./organizations.html" class="nav-link">Organizations</a>
+        </li>
+      </ul>
+    </nav>
+  <!-- DIV CONTAINING PROFILE AND CARDS -->
+  <div class="d-flex flex-lg-row flex-wrap m-lg-5">
+      <div class="me-lg-3" id="profile-card">
+  <!-- PROFILE CARD PRINTED HERE  -->
+      </div>
+  <!-- DIV CONTAINING FORM AND CARDS -->
+    <div class="d-flex flex-lg-column flex-wrap mt-lg-3">
+      <div class="container d-flex flex-wrap" id="package-container"></div>
+        <div class="container">  
+          <div class= "mt-4" id="package-form-container">
+            <div class="mb-3">
+              <label for="title" class="form-label">Name</label>
+              <input
+                type="text"
+                class="form-control"
+                id="package-name"
+                placeholder="New Package Name"
+              />
+            </div>
+            <div class="mb-3">
+              <label for="package-img-src" class="form-label">Package Icon URL</label>
+              <input
+                type="text"
+                class="form-control"
+                id="package-img-src"
+                placeholder="Icon URL"
+              />
+            </div>
+            <div>
+              <label for="description" class="form-label">Description</label>
+              <textarea
+                class="form-control"
+                id="package-description"
+                rows="6"
+              ></textarea>
+            </div>
+            <button type="button" class="btn btn-outline-info" id="create-package">Submit</button>
+          </div>
       </div>
     </div>
-  </div> 
-<!-- Footer -->
-    <nav class="navbar navbar-expand-lg fixed-bottom navbar-light bg-light">
+  </div>
+
+  <!-- FOOTER -->
+    <footer class="navbar navbar-expand-lg d-flex justify-content-left">
       <div class="container-fluid">
         <a class="navbar-brand" href="#">@ 2021 Github, Inc.</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
@@ -118,15 +123,14 @@
           </ul>
         </div>
       </div>
-    </nav>
+    </footer>
 
-<!-- Bootstrap Script -->
+  <!-- SCRIPTS -->
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW"
       crossorigin="anonymous">
     </script>
-<!-- JS Script -->
     <script src="main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixed styling on the Packages Page
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
- Added responsive design to the content in the packages page
- Reformatted the cards and layout in the Div containing my page cards

## Related Issue
https://github.com/nss-evening-cohort-14/gitsub-e14-team-2-electric-boogaloo/issues/67

## Motivation and Context
Required for MVP and general UI ease of use. 

## How Can This Be Tested?
```
git fetch origin sr-packages-styling
sudo hs -o
```

## Screenshots (if appropriate):
<img width="1788" alt="Screen Shot 2021-02-13 at 9 23 04 AM" src="https://user-images.githubusercontent.com/76828201/107853709-173ce980-6ddd-11eb-93fe-37eb6192c479.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
